### PR TITLE
stagelinq-discover: use %v to render map[string]interface{} values (#26)

### DIFF
--- a/cmd/stagelinq-discover/main.go
+++ b/cmd/stagelinq-discover/main.go
@@ -153,7 +153,7 @@ discoveryLoop:
 							stateMapConn.Subscribe(stateValue)
 						}
 						for state := range stateMapConn.StateC() {
-							log.Printf("\t%s = %s", state.Name, state.Value)
+							log.Printf("\t%s = %v", state.Name, state.Value)
 							m[state.Name] = true
 							if allStateValuesReceived(m) {
 								break


### PR DESCRIPTION
As referenced in #26, us `%v` to render `map[string]interface{}` values in `stagelinq-discover`.