### PR TITLE
add Device.Token() method for #35

### DIFF
--- a/device.go
+++ b/device.go
@@ -58,6 +58,11 @@ func (device *Device) IsEqual(anotherDevice *Device) bool {
 		device.SoftwareVersion == anotherDevice.SoftwareVersion
 }
 
+// Token returns the unique token for the device.
+func (device *Device) Token() Token {
+	return device.token
+}
+
 func newDeviceFromDiscovery(addr *net.UDPAddr, msg *discoveryMessage) *Device {
 	return &Device{
 		port:  msg.Port,


### PR DESCRIPTION
Currently there's no way to retrieve a remote device's token and retrieve that stable identifier.

This PR adds a trivial `Device.Token()` method to return a device's token. Existing unit tests pass.